### PR TITLE
release/2.0.0: Create 2.0.0 release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: ci
+name: cd
 on:
   push:
     branches: [main]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: Publish docs.yml"
-          file_pattern: "docs.yml/*"
+          file_pattern: "docs/*"
           add_options: "-f"
           skip_dirty_check: true
           commit_user_name: brandon14

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 | Dependency                    | Version                              |
 |-------------------------------|--------------------------------------|
 | php                           | ^7.4 \|\| ^8.0                       |
-| brandon14/fossabot-commander  | ^1.0.0                               |
+| brandon14/fossabot-commander  | ^1.0.2                               |
 | guzzlehttp/guzzle             | ^6.5.8 \|\| ^7.4.5                   |
 | illuminate/console            | ^8.0 \|\| ^9.0 \|\| ^10.0 \|\| ^11.0 |
 | illuminate/support            | ^8.0 \|\| ^9.0 \|\| ^10.0 \|\| ^11.0 |

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ class Controller extends BaseController
 To make commands via the Artisan command:
 
 ```bash
-php artisan make:fossabot-command NameOfCommand
+php artisan fossabot:make:command NameOfCommand
 ```
 
 ## Standards

--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
   <a href="https://packagist.org/packages/brandon14/fossabot-commander-laravel" target="_blank"><img alt="Packagist PHP Version" src="https://img.shields.io/packagist/dependency-v/brandon14/fossabot-commander-laravel/php?style=for-the-badge&cacheSeconds=3600"></a>
 </p>
 <p align="center">
-  <a href="https://github.com/brandon14/fossabot-commander-laravel/actions/workflows/run-tests.yml" 
-target="_blank"><img alt="GitHub Workflow Status (with event)" src="https://img.shields.
-io/github/actions/workflow/status/brandon14/fossabot-commander-laravel/run-tests.yml?
-style=for-the-badge&cacheSeconds=3600">
+  <a href="https://github.com/brandon14/fossabot-commander-laravel/actions/workflows/run-tests.yml" target="_blank"><img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/brandon14/fossabot-commander-laravel/run-tests.yml?style=for-the-badge&cacheSeconds=3600">
   </a>
   <a href="https://codeclimate.com/github/brandon14/fossabot-commander-laravel/maintainability" target="_blank"><img alt="Code Climate maintainability" src="https://img.shields.io/codeclimate/maintainability-percentage/brandon14/fossabot-commander-laravel?style=for-the-badge&cacheSeconds=3600">
   </a>

--- a/composer.json
+++ b/composer.json
@@ -106,9 +106,9 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev",
-            "dev-main": "1.0-dev",
-            "dev-latest": "1.0-dev"
+            "dev-master": "2.0-dev",
+            "dev-main": "2.0-dev",
+            "dev-latest": "2.0-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "brandon14/fossabot-commander": "^1.0.0",
+        "brandon14/fossabot-commander": "^1.0.2",
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.4.5",
         "illuminate/console": "^8.0 || ^9.0 || ^10.0 || ^11.0",

--- a/config/fossabot-commander.php
+++ b/config/fossabot-commander.php
@@ -55,6 +55,18 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Include Additional Logging Context
+        |--------------------------------------------------------------------------
+        |
+        | This options controls whether additional FossabotCommander context should
+        | be included when calling logger methods.
+        |
+        */
+
+        'include_context' => env('FOSSABOT_COMMANDER_INCLUDE_LOGGING_CONTEXT', true),
+
+        /*
+        |--------------------------------------------------------------------------
         | Logging Channel
         |--------------------------------------------------------------------------
         |

--- a/doctum.dist.php
+++ b/doctum.dist.php
@@ -43,7 +43,8 @@ $iterator = Finder::create()
 $versions = GitVersionCollection::create($dir)
     ->addFromTags('v*')
     ->add('main', 'main')
-    ->add('1.0-dev', '1.0-dev');
+    ->add('1.0-dev', '1.0-dev')
+    ->add('2.0-dev', '2.0-dev');
 
 return new Doctum($iterator, [
     'versions' => $versions,

--- a/licenses.md
+++ b/licenses.md
@@ -35,7 +35,7 @@ SOFTWARE.
 
 ## Dependencies
 
-### brandon14/fossabot-commander (Version v1.0.0 | 73b8109)
+### brandon14/fossabot-commander (Version v1.0.2 | c31399f)
 Library to easily create Fossabot commands invokable via the Fossabot customapi implementation.
 Homepage: [https://github.com/brandon14/fossabot-commander](https://github.com/brandon14/fossabot-commander)
 Licenses Used: MIT
@@ -293,7 +293,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-### guzzlehttp/guzzle (Version 7.8.1 | 41042bc)
+### guzzlehttp/guzzle (Version 7.9.1 | a629e5b)
 Guzzle is a PHP HTTP client library
 Homepage: Not configured.
 Licenses Used: MIT
@@ -326,7 +326,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-### guzzlehttp/promises (Version 2.0.2 | bbff78d)
+### guzzlehttp/promises (Version 2.0.3 | 6ea8dd0)
 Guzzle promises library
 Homepage: Not configured.
 Licenses Used: MIT
@@ -356,7 +356,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-### guzzlehttp/psr7 (Version 2.6.2 | 45b30f9)
+### guzzlehttp/psr7 (Version 2.7.0 | a70f5c9)
 PSR-7 message implementation that also provides common utility methods
 Homepage: Not configured.
 Licenses Used: MIT

--- a/src/Commands/MakeFossabotCommand.php
+++ b/src/Commands/MakeFossabotCommand.php
@@ -49,7 +49,7 @@ final class MakeFossabotCommand extends GeneratorCommand
     /**
      * {@inheritDoc}
      */
-    protected $signature = 'make:fossabot-command
+    protected $signature = 'fossabot:make:command
                             {name : Name of command class}
                             {--force : Whether to overwrite command if it already exists}';
 

--- a/src/FossabotCommanderServiceProvider.php
+++ b/src/FossabotCommanderServiceProvider.php
@@ -69,8 +69,11 @@ final class FossabotCommanderServiceProvider extends ServiceProvider
         // Bind FossabotCommander as singleton.
         $this->app->singleton(FossabotCommanderInterface::class, static function (Container $app) {
             $config = $app->make('config')->get('fossabot-commander');
-            $logging = $config['logging']['enable'];
-            $channel = $config['logging']['channel'];
+            $logging = isset($config['logging']['enable']) && $config['logging']['enable'];
+            $channel = isset($config['logging']['channel']) ? (string) $config['logging']['channel'] : 'default';
+            /** @noinspection PhpVariableNamingConventionInspection */
+            $includeLogContext = isset($config['logging']['include_context'])
+                && $config['logging']['include_context'];
 
             // If logging is enabled, get the logger for the configured channel, otherwise set as null.
             $logger = $logging ? $app->make('log')->channel($channel) : null;
@@ -93,7 +96,7 @@ final class FossabotCommanderServiceProvider extends ServiceProvider
                 $request = $app->make(HttpFactory::class);
             }
 
-            return new FossabotCommander($http, $request, $logger, $logging);
+            return new FossabotCommander($http, $request, $logger, $logging, $includeLogContext);
         });
 
         // Add alias.


### PR DESCRIPTION
## Proposed Changes

- Fixes the git add pattern to add built docs in the docs.yml workflow.
- Renames CI workflow to CD.
- Updates Shields.io badge in README.md
- Adds support for new includeLogContext feature in latest fossabot-commander package.
- [breaking] Namespaces make command to `fossabot:make:command`.
- For the upcoming BC release of 2.0.0, update branch aliases to reflect that change.
- Build Doctum docs for 2.0-dev branch.
- 2.0.0 will require ^1.0.2 of fossabot-commander package.