### PR TITLE
feat(docs): Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,27 @@ jobs:
           method: "update"
           cli-args: "--output-format=github --no-ansi --no-progress --ignore-parse-errors -v"
 
+      - name: Build docs index file
+        uses: DamianReeves/write-file-action@master
+        with:
+          path: docs/index.html
+          write-mode: "overwrite"
+          contents: |
+            <!doctype HTML>
+            <html lang="en-US">
+              <head>
+                <meta charset="UTF-8">
+                <meta http-equiv="refresh" content="0; url=${{ github.ref_name }}/index.html">
+                <script type="text/javascript">
+                  window.location.href = "${{ github.ref_name }}/index.html"
+                </script>
+                <title>docs Redirect</title>
+              </head>
+              <body>
+                If you are not redirected automatically, follow this <a href='${{ github.ref_name }}/index.html'>link to the docs page</a>.
+              </body>
+            </html>
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,11 +36,12 @@ jobs:
         with:
           ref: gh-pages
           fetch-depth: 0
+          clean: false
 
       - name: Commit doc changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: Publish docs.yml"
+          commit_message: "chore: Publish docs"
           file_pattern: "docs/*"
           add_options: "-f"
           skip_dirty_check: true


### PR DESCRIPTION
- When checking back out to gh-pages after building the docs, we need to ensure it doesn't clean the repo as it will drop all the docs generated.
- Adds a step to the docs workflow to create an index file in the root of the docs folder to redirect to the latest version docs.
