### PR TITLE
release: v2.0.1 release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
             commit_message: "chore: Update CHANGELOG.md"
             commit_user_name: brandon14
             commit_user_email: brandon14125@gmail.com
-            commit_options: '-S --force'
+            commit_options: '-S'
 
         - name: Update contributors
           uses: minicli/action-contributors@v3
@@ -61,4 +61,4 @@ jobs:
             commit_message: "chore: Update CONTRIBUTORS.md"
             commit_user_name: brandon14
             commit_user_email: brandon14125@gmail.com
-            commit_options: '-S --force'
+            commit_options: '-S'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,27 @@ jobs:
           method: "update"
           cli-args: "--output-format=github --no-ansi --no-progress --ignore-parse-errors -v"
 
+      - name: Build docs index file
+        uses: DamianReeves/write-file-action@master
+        with:
+          path: docs/index.html
+          write-mode: "overwrite"
+          contents: |
+            <!doctype HTML>
+            <html lang="en-US">
+              <head>
+                <meta charset="UTF-8">
+                <meta http-equiv="refresh" content="0; url=${{ github.ref_name }}/index.html">
+                <script type="text/javascript">
+                  window.location.href = "${{ github.ref_name }}/index.html"
+                </script>
+                <title>docs Redirect</title>
+              </head>
+              <body>
+                If you are not redirected automatically, follow this <a href='${{ github.ref_name }}/index.html'>link to the docs page</a>.
+              </body>
+            </html>
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:
@@ -36,11 +57,12 @@ jobs:
         with:
           ref: gh-pages
           fetch-depth: 0
+          clean: false
 
       - name: Commit doc changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: Publish docs.yml"
+          commit_message: "chore: Publish docs"
           file_pattern: "docs/*"
           add_options: "-f"
           skip_dirty_check: true

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - 1.0-dev
+      - 2.0-dev
       - gh-pages
 
 jobs:
@@ -39,4 +40,5 @@ jobs:
         with:
           commit_message: "chore: Fix styling from PHP-CS-Fixer"
           commit_user_name: brandon14
+          commit_user_email: brandon14125@gmail.com
           commit_options: '-S'


### PR DESCRIPTION
v2.0.1 release

- There were invalid commit options included in the CD workflow.

- This also adds the email to the php-cs-fixer workflow for committing.

- Adds a step to the docs workflow to create an index file in the root of the docs folder to redirect to the latest version docs.

- When checking back out to gh-pages after building the docs, we need to ensure it doesn't clean the repo as it will drop all the docs generated.